### PR TITLE
Fix list miscounting in sg_set_valid_filesystems.

### DIFF
--- a/src/libstatgrab/disk_stats.c
+++ b/src/libstatgrab/disk_stats.c
@@ -594,7 +594,9 @@ sg_set_valid_filesystems(const char *valid_fs[]) {
 	/* XXX this must be locked - from caller ? */
 	if( valid_fs && *valid_fs ) {
 
-		while( valid_fs[num_new_valid_fs++] ) {} /* Note: post-inc is intensional */
+		while( valid_fs[num_new_valid_fs] ) {
+			num_new_valid_fs++;
+		}
 
 		new_valid_fs = calloc( num_new_valid_fs + 1, sizeof(char *) );
 		if( 0 == new_valid_fs ) {


### PR DESCRIPTION
Previously this counted the NULL entry that terminated the list -- so
the length was set to be one too high, and reading the list back with
sg_get_valid_filesystems would produce a spurious NULL at the end.

For example, try this before and afterwards:

```
#include <stdio.h>
#include <statgrab.h>

int main() {
    sg_init(0);

    for (int j = 0; j < 3; j++) {

        size_t n;
        const char **s = sg_get_valid_filesystems(&n);
        for (int i = 0; i < n; i++) {
            printf("fs[%d] = '%s'\n", i, s[i]);
        }

        const char *new[] = {
            "ext4",
            "isofs",
            NULL
        };
        sg_set_valid_filesystems(new);

        printf("\n");

    }

    return 0;
}
```
