### PR TITLE
updated print_stat to flush to stdout

### DIFF
--- a/src/statgrab/statgrab.c
+++ b/src/statgrab/statgrab.c
@@ -742,6 +742,7 @@ print_stat(const stat_item *s) {
 	}
 	print_stat_value(s);
 	printf("\n");
+	fflush(stdout);
 }
 
 /* Print stats as specified on the provided command line. */


### PR DESCRIPTION
statgrab should flush to stdout so it can be used with pipes
