### PR TITLE
Fix tests when using a VPATH build.

### DIFF
--- a/tests/multi_threaded/Makefile.am
+++ b/tests/multi_threaded/Makefile.am
@@ -21,14 +21,14 @@ $(top_builddir)/src/libstatgrab/libstatgrab.la:
 
 if TEST_SCRIPTS
 full_stats_edit=	$(PERL5) $(srcdir)/../testlib/mk_run_tests.pl \
-		-d srcdir="$(srcdir)" \
+		-d srcdir="$(abs_srcdir)" \
 		-d test-bin="full_stats" \
 		-d test-name=full-stats \
 		-d test-dir="$(subdir)" \
 		-f synopsis=$(srcdir)/run_tests.synopsis.in
 
 diff_stats_edit=	$(PERL5) $(srcdir)/../testlib/mk_run_tests.pl \
-		-d srcdir="$(srcdir)" \
+		-d srcdir="$(abs_srcdir)" \
 		-d test-bin="diff_stats" \
 		-d test-name=diff-stats \
 		-d test-dir="$(subdir)" \

--- a/tests/single_threaded/Makefile.am
+++ b/tests/single_threaded/Makefile.am
@@ -21,14 +21,14 @@ $(top_builddir)/src/libstatgrab/libstatgrab.la:
 
 if TEST_SCRIPTS
 full_stats_edit=	$(PERL5) $(srcdir)/../testlib/mk_run_tests.pl \
-		-d srcdir="$(srcdir)" \
+		-d srcdir="$(abs_srcdir)" \
 		-d test-bin="full_stats" \
 		-d test-name=full-stats \
 		-d test-dir="$(subdir)" \
 		-f synopsis=$(srcdir)/run_tests.synopsis.in
 
 diff_stats_edit=	$(PERL5) $(srcdir)/../testlib/mk_run_tests.pl \
-		-d srcdir="$(srcdir)" \
+		-d srcdir="$(abs_srcdir)" \
 		-d test-bin="diff_stats" \
 		-d test-name=diff-stats \
 		-d test-dir="$(subdir)" \


### PR DESCRIPTION
The problem is that App::Prove (or whatever it uses) doesn't chdir to the directory before running the tests. So the relative include path in the .t file is only valid if you're inside the single_threaded or multi_threaded directories. Running the tests from there works fine, but if you run it from the directory above the relative path points to the wrong place and it breaks. This change uses an absolute path so it works in both cases.

An alternative fix would be to modify the Makefile in tests to chdir to each sub-directory before launching App::Prove, or if App::Prove has a way of doing the chdir itself that'd also work.

Fixes #43.
