### PR TITLE
add support for system-wide logging properties

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -22,11 +22,36 @@ endif
 
 check: test
 
-EXTRA_DIST = libstatgrab.pc.in
+EXTRA_DIST = libstatgrab.pc.in statgrab.properties.in saidar.properties.in
 
 MAINTAINERCLEANFILES = ChangeLog
 
 dist_doc_DATA = NEWS PLATFORMS README AUTHORS COPYING COPYING.LGPL
+
+if WITH_LIBLOG4CPLUS
+sysconf_DATA = statgrab.properties saidar.properties
+
+prop_edit=	-e 's|@localstatedir[@]|$(localstatedir)|g'
+prop_edit_cmd=	$(SED) $(prop_edit)
+
+statgrab.properties: Makefile $(srcdir)/statgrab.properties.in
+	rm -f $@ $@.tmp
+	srcdir=''; \
+	  test -f ./$@.in || srcdir=$(srcdir)/; \
+	  $(prop_edit_cmd) $${srcdir}$@.in >$@.tmp
+	chmod +r $@.tmp
+	chmod a-wx $@.tmp
+	mv $@.tmp $@
+
+saidar.properties: Makefile $(srcdir)/saidar.properties.in
+	rm -f $@ $@.tmp
+	srcdir=''; \
+	  test -f ./$@.in || srcdir=$(srcdir)/; \
+	  $(prop_edit_cmd) $${srcdir}$@.in >$@.tmp
+	chmod +r $@.tmp
+	chmod a-wx $@.tmp
+	mv $@.tmp $@
+endif
 
 pkgconfigdir = $(libdir)/pkgconfig
 pkgconfig_DATA = libstatgrab.pc

--- a/saidar.properties.in
+++ b/saidar.properties.in
@@ -1,0 +1,5 @@
+log4cplus.logger.statgrab=TRACE, LOGFILE
+
+log4cplus.appender.LOGFILE=log4cplus::FileAppender
+log4cplus.appender.LOGFILE.File=@localstatedir@/saidar.log4cplus
+log4cplus.appender.LOGFILE.layout=log4cplus::TTCCLayout

--- a/src/libstatgrab/Makefile.am
+++ b/src/libstatgrab/Makefile.am
@@ -2,7 +2,11 @@
 # http://www.i-scream.org/libstatgrab/
 # $Id$
 
+if WITH_LIBLOG4CPLUS
+AM_CPPFLAGS = $(PTHREAD_CFLAGS) -DBUILD_LIBSTATGRAB -DPROPERTIES_SEARCH_DIR="\"$(sysconfdir)\"" @CLIBFLAGS@
+else
 AM_CPPFLAGS = $(PTHREAD_CFLAGS) -DBUILD_LIBSTATGRAB @CLIBFLAGS@
+endif
 
 include_HEADERS = statgrab.h
 lib_LTLIBRARIES = libstatgrab.la

--- a/statgrab.properties.in
+++ b/statgrab.properties.in
@@ -1,5 +1,5 @@
 log4cplus.logger.statgrab=TRACE, LOGFILE
 
 log4cplus.appender.LOGFILE=log4cplus::FileAppender
-log4cplus.appender.LOGFILE.File=./saidar.log4cplus
+log4cplus.appender.LOGFILE.File=@localstatedir@/statgrab.log4cplus
 log4cplus.appender.LOGFILE.layout=log4cplus::TTCCLayout


### PR DESCRIPTION
- when installing libstatgrab with log4cplus, enable search in sysconfdir
  for properties files, too
- deploy default properties when log4cplus enabled
