### PR TITLE
fetch thread name from comm, if available

### DIFF
--- a/src/libstatgrab/process_stats.c
+++ b/src/libstatgrab/process_stats.c
@@ -293,7 +293,6 @@ adjust_procname_cmndline(char *proctitle, size_t len) {
 }
 #endif
 
-
 static sg_error
 sg_get_process_stats_int(sg_vector **proc_stats_vector_ptr) {
 
@@ -302,12 +301,16 @@ sg_get_process_stats_int(sg_vector **proc_stats_vector_ptr) {
 	time_t now = time(NULL);
 
 #if defined(LINUX)
+#define READBUF_LENGTH 4095
+	static const char proc_stat_fmt_base[] = "%" FMT_PID_T " %s %%c %" FMT_PID_T " %" FMT_PID_T " %%*d %%*d %%*d %%*u %%*u %%*u %%*u %%*u %%lu %%lu %%*d %%*d %%*d %%d %%*d %%*d %%llu %%llu %%llu %%*u %%*u %%*u %%*u %%*u %%*u %%*u %%*u %%*u %%*u %%*u %%*u %%*u %%*d %%*d";
+	static const char proc_stat_fmt_default[] = FMT_PID_T " %4095s %c " FMT_PID_T " " FMT_PID_T " %*d %*d %*d %*u %*u %*u %*u %*u %lu %lu %*d %*d %*d %d %*d %*d %llu %llu %llu %*u %*u %*u %*u %*u %*u %*u %*u %*u %*u %*u %*u %*u %*d %*d";
 	struct pids_in_proc_dir_t *pids_in_proc_dir;
 	size_t pid_item = 0;
 	char filename[MAX_FILE_LENGTH];
 	FILE *f;
 	char s;
-	char read_buf[4096];
+	char read_buf[READBUF_LENGTH+1];
+	char proc_stat_fmt[sizeof proc_stat_fmt_base];
 	char *read_ptr;
 	/* XXX or we detect max command line length in ./configure */
 	unsigned long stime, utime;
@@ -466,6 +469,39 @@ sg_get_process_stats_int(sg_vector **proc_stats_vector_ptr) {
 			continue;
 		}
 
+		snprintf(filename, MAX_FILE_LENGTH, PROC_LOCATION "/" FMT_PID_T "/comm", pids_in_proc_dir->items[pid_item]);
+		if( ( f = fopen(filename, "r") ) == NULL ) {
+			/* Open failed.. */
+			proc_stat_fmt[0] = read_buf[0] = '\0';
+		}
+		else {
+			char *tok, *tok_e;
+			char comm_jmp[32] = { '\0' }; /* procfs documents comm with 16 chars max */
+			fgets(read_buf, READBUF_LENGTH, f);
+			fclose(f);
+			read_buf[sizeof read_buf - 1] = '\0';
+
+			tok = read_buf;
+			tok_e = read_buf + strlen(read_buf) - 1;
+			if(*tok_e == '\n')
+				*tok_e-- = '\0';
+
+			strncat(comm_jmp, "%*s", sizeof(comm_jmp) - strlen(comm_jmp) - 1);
+			while(tok <= tok_e) {
+				if(isspace(*tok)) {
+					strncat(comm_jmp, " ", sizeof(comm_jmp) - strlen(comm_jmp) - 1);
+					strncat(comm_jmp, "%*s", sizeof(comm_jmp) - strlen(comm_jmp) - 1);
+
+					while(isspace(*tok) && tok <= tok_e)
+						++tok;
+				}
+
+				++tok;
+			}
+
+			snprintf(proc_stat_fmt, sizeof(proc_stat_fmt), proc_stat_fmt_base, comm_jmp);
+		}
+
 		snprintf(filename, MAX_FILE_LENGTH, PROC_LOCATION "/" FMT_PID_T "/stat", pids_in_proc_dir->items[pid_item]);
 		if( ( f = fopen(filename, "r") ) == NULL ) {
 			/* Open failed.. Process since vanished, or the path was too long.
@@ -476,10 +512,20 @@ sg_get_process_stats_int(sg_vector **proc_stats_vector_ptr) {
 
 		VECTOR_UPDATE(proc_stats_vector_ptr, proc_items + 1, proc_stats_ptr, sg_process_stats);
 
-		if( fscanf(f, FMT_PID_T "%4095s %c " FMT_PID_T " " FMT_PID_T " %*d %*d %*d %*u %*u %*u %*u %*u %lu %lu %*d %*d %*d %d %*d %*d %llu %llu %llu %*u %*u %*u %*u %*u %*u %*u %*u %*u %*u %*u %*u %*u %*d %*d\n",
-			   &proc_stats_ptr[proc_items].pid, read_buf, &s, &proc_stats_ptr[proc_items].parent,
-			   &proc_stats_ptr[proc_items].pgid, &utime, &stime, &proc_stats_ptr[proc_items].nice,
-			   &starttime, &proc_stats_ptr[proc_items].proc_size, &proc_stats_ptr[proc_items].proc_resident) < 11 ) {
+		if( proc_stat_fmt[0] ) {
+			rc = fscanf(f, proc_stat_fmt,
+			       &proc_stats_ptr[proc_items].pid, &s, &proc_stats_ptr[proc_items].parent,
+			       &proc_stats_ptr[proc_items].pgid, &utime, &stime, &proc_stats_ptr[proc_items].nice,
+			       &starttime, &proc_stats_ptr[proc_items].proc_size, &proc_stats_ptr[proc_items].proc_resident);
+		}
+		else {
+			rc = fscanf(f, proc_stat_fmt_default,
+			       &proc_stats_ptr[proc_items].pid, read_buf, &s, &proc_stats_ptr[proc_items].parent,
+			       &proc_stats_ptr[proc_items].pgid, &utime, &stime, &proc_stats_ptr[proc_items].nice,
+			       &starttime, &proc_stats_ptr[proc_items].proc_size, &proc_stats_ptr[proc_items].proc_resident);
+		}
+
+		if( (proc_stat_fmt[0] && rc < 10) || (proc_stat_fmt[0] == '\0' && rc < 11)) {
 			/* Read failed.. Process vanished?
 			 * Ah well, move onwards to the next one */
 			++pid_item;
@@ -505,12 +551,14 @@ sg_get_process_stats_int(sg_vector **proc_stats_vector_ptr) {
 		}
 
 		/* pa_name[0] should = '(' */
+		rc = 0;
 		read_ptr = strchr(&read_buf[1], ')');
 		if( read_ptr != NULL ) {
 			*read_ptr = '\0';
+			rc = 1;
 		}
 
-		if( SG_ERROR_NONE != sg_update_string( &proc_stats_ptr[proc_items].process_name, &read_buf[1] )) {
+		if( SG_ERROR_NONE != sg_update_string( &proc_stats_ptr[proc_items].process_name, &read_buf[rc] )) {
 			VECTOR_UPDATE_ERROR_CLEANUP
 			RETURN_FROM_PREVIOUS_ERROR( "process", sg_get_error() );
 		}


### PR DESCRIPTION
Since sg_get_process_stats eliminates surrounding brackets either when
comm (thread name of active thread of a process) is taken from stat
file, read it pure from comm.
Because of some firmware drivers create names containing spaces, this is
safer than parsing unknown number elements in front of stat content.
