### PR TITLE
On FreeBSD 12+ vmmeter.v_cache_count is removed.

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -1166,6 +1166,22 @@ AC_INCLUDES_DEFAULT
 #endif
 		])])
 
+			AC_CHECK_MEMBER(struct vmmeter.v_cache_count,
+					[AC_DEFINE(HAVE_VMMETER_V_CACHE_COUNT, 1, [v_cache_count member of struct vmmeter available])], ,
+					[AC_LANG_SOURCE([
+AC_INCLUDES_DEFAULT
+#ifdef HAVE_SYS_PARAM_H
+# include <sys/param.h>
+#endif
+#ifdef HAVE_SYS_SYSCTL_H
+# include <sys/sysctl.h>
+#endif
+#ifdef HAVE_SYS_VMMETER_H
+# include <sys/vmmeter.h>
+#endif
+					]
+			)])
+
 		AC_CHECK_TYPES([struct xswdev, struct xsw_usage], , , [AC_LANG_SOURCE([
 AC_INCLUDES_DEFAULT
 #ifdef HAVE_SYS_PARAM_H

--- a/src/libstatgrab/memory_stats.c
+++ b/src/libstatgrab/memory_stats.c
@@ -323,10 +323,14 @@ sg_get_mem_stats_int(sg_mem_stats *mem_stats_buf) {
 		RETURN_WITH_SET_ERROR_WITH_ERRNO("mem", SG_ERROR_SYSCTLBYNAME, "vm.stats.vm.v_inactive_count");
 	}
 
+# if defined(HAVE_VMMETER_V_CACHE_COUNT)
 	size = sizeof(cache_count);
 	if (sysctlbyname("vm.stats.vm.v_cache_count", &cache_count, &size, NULL, 0) < 0) {
 		RETURN_WITH_SET_ERROR_WITH_ERRNO("mem", SG_ERROR_SYSCTLBYNAME, "vm.stats.vm.v_cache_count");
 	}
+# else
+	cache_count = 0;
+# endif
 
 	/* Of couse nothing is ever that simple :) And I have inactive pages to
 	 * deal with too. So I'm going to add them to free memory :)


### PR DESCRIPTION
See:

https://reviews.freebsd.org/D8583
https://svnweb.freebsd.org/base?view=revision&revision=309017

Dummy values (always returning 0) were added if COMPAT_FREEBSD11 is defined. This is defined in GENERIC, so will be there for most users.

This fixes #103 by testing for vmmeter.v_cache_count and setting the cache value to 0 if it doesn't exist. However, more investigation may need to be done to see if cache can be obtained in a different way.