### PR TITLE
Solaris: don't skip interfaces with partial data.

### DIFF
--- a/src/libstatgrab/network_stats.c
+++ b/src/libstatgrab/network_stats.c
@@ -553,35 +553,28 @@ sg_get_network_io_stats_int(sg_vector **network_io_stats_vector_ptr){
 			network_io_ptr[interfaces].rx=knp->VALTYPE;
 
 			/* Read tx */
-			if((knp=kstat_data_lookup(ksp, LTX))==NULL)
-				continue;
-			network_io_ptr[interfaces].tx=knp->VALTYPE;
+			if((knp=kstat_data_lookup(ksp, LTX))!=NULL)
+				network_io_ptr[interfaces].tx=knp->VALTYPE;
 
 			/* Read ipackets */
-			if((knp=kstat_data_lookup(ksp, LIPACKETS))==NULL)
-				continue;
-			network_io_ptr[interfaces].ipackets=knp->VALTYPE;
+			if((knp=kstat_data_lookup(ksp, LIPACKETS))!=NULL)
+				network_io_ptr[interfaces].ipackets=knp->VALTYPE;
 
 			/* Read opackets */
-			if((knp=kstat_data_lookup(ksp, LOPACKETS))==NULL)
-				continue;
-			network_io_ptr[interfaces].opackets=knp->VALTYPE;
+			if((knp=kstat_data_lookup(ksp, LOPACKETS))!=NULL)
+				network_io_ptr[interfaces].opackets=knp->VALTYPE;
 
 			/* Read ierrors */
-			if((knp=kstat_data_lookup(ksp, "ierrors"))==NULL)
-				continue;
-			network_io_ptr[interfaces].ierrors=knp->value.ui32;
+			if((knp=kstat_data_lookup(ksp, "ierrors"))!=NULL)
+				network_io_ptr[interfaces].ierrors=knp->value.ui32;
 
 			/* Read oerrors */
-			if((knp=kstat_data_lookup(ksp, "oerrors"))==NULL)
-				continue;
-			network_io_ptr[interfaces].oerrors=knp->value.ui32;
+			if((knp=kstat_data_lookup(ksp, "oerrors"))!=NULL)
+				network_io_ptr[interfaces].oerrors=knp->value.ui32;
 
 			/* Read collisions */
-			if((knp=kstat_data_lookup(ksp, "collisions"))==NULL)
-				continue;
-			network_io_ptr[interfaces].collisions=knp->value.ui32;
-
+			if((knp=kstat_data_lookup(ksp, "collisions"))!=NULL)
+				network_io_ptr[interfaces].collisions=knp->value.ui32;
 
 			/* Store systime */
 			network_io_ptr[interfaces].systime=time(NULL);


### PR DESCRIPTION
In testing of VLANed interfaces it became apparent that they don't have all data items (notably "collisions") which resulted in us skipping over the interface. I've reworked this to only include the data items that are present and not skip the interface.

This also fixes a bug caused by us increasing the vector size and partially populating it before skipping on to the next interface. Because the interfaces counter wasn't incremented the next loop around would overwrite this partial entry. This caused at best confusion if the skipped interfaces were last in the list; "why is only the last of these odd interfaces appearing?", and at worst an interface entry with a mixture of a skipped interface and an actual one. By not skipping interfaces we avoid this problem.

Should be rebased and re-tested after merging #99.