### PR TITLE
Ensure modern log4cplus is used correctly

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -1782,6 +1782,8 @@ AS_IF([test "x$ENABLE_LOGGING" != "xno"], [
 
     AS_IF([test "x$WITH_LIBLOG4CPLUS" = "x1"], [
       AC_LANG_PUSH([C++])
+      # necessary to avoid empty $CXX
+      AC_PROG_CXX
       AC_MSG_CHECKING([if liblog4cplus is built with thread support])
       ax_cppflags_safe="$CPPFLAGS"
       CPPFLAGS="$CPPFLAGS $CLIBFLAGS"
@@ -1804,6 +1806,11 @@ AS_IF([test "x$ENABLE_LOGGING" != "xno"], [
       )
       CPPFLAGS="$ax_cppflags_safe"
       AC_LANG_POP([C++])
+
+      ax_save_libs="$LIBS"
+      LIBS="$LIBS $LINKFLAGS"
+      AC_CHECK_FUNCS([log4cplus_initialize log4cplus_add_log_level])
+      LIBS="$ax_save_libs"
     ])
 
     AS_IF([test "x$ENABLE_LOGGING" = "xyes" -a "x$WITH_LIBLOG4CPLUS" != "x1"],

--- a/docs/libstatgrab/sg_init.xml
+++ b/docs/libstatgrab/sg_init.xml
@@ -20,6 +20,12 @@
     <funcsynopsis>
       <funcsynopsisinfo>#include &lt;statgrab.h&gt;</funcsynopsisinfo>
       <funcprototype>
+        <funcdef>void <function>sg_log_init</function></funcdef>
+        <paramdef>const char *<parameter>properties_pfx</parameter></paramdef>
+        <paramdef>const char *<parameter>env_name</parameter></paramdef>
+        <paramdef>const char *<parameter>argv0</parameter></paramdef>
+      </funcprototype>
+      <funcprototype>
         <funcdef>sg_error <function>sg_init</function></funcdef>
         <paramdef>int <parameter>ignore_init_errors</parameter></paramdef>
       </funcprototype>
@@ -53,6 +59,14 @@
       &quot;statgrab&quot;.
     </para>
     <para>
+      <function>sg_log_init</function>() allowes some application-individual
+      logging configuration. It's intended for projects with several applications
+      or commands which might have different appenders.
+      Mind that <function>sg_log_init</function> must be called before
+      <function>sg_init</function>, but after your application initialized
+      logging framework.
+    </para>
+    <para>
       <function>sg_snapshot</function>() is Win32 only and will probably disappear.
     </para>
     <para>
@@ -74,6 +88,41 @@
       All functions return a statgrab error code. Either
       <errorcode>SG_ERROR_NONE</errorcode> when everything was ok or the
       appropriate error code from an constructor/destructor.
+    </para>
+  </refsect1>
+
+  <refsect1>
+    <title>Example</title>
+    <para>
+      Typical initialization/deinitialization sequence when using with log4cplus:
+      <programlisting>
+static void *l4cplus_initializer;
+
+static void
+cleanup_logging(void)
+{
+       log4cplus_deinitialize(l4cplus_initializer);
+}
+
+int
+main(int argc, char const *argv[])
+{
+    l4cplus_initializer = log4cplus_initialize();
+    atexit((void (*)(void))cleanup_logging);
+
+    sg_log_init("saidar", "SAIDAR_LOG_PROPERTIES", argv[0]);
+    sg_init(1);
+    if(sg_drop_privileges() != 0) {
+	die("Failed to drop setuid/setgid privileges");
+    }
+
+    do_something();
+
+    sg_shutdown();
+
+    return 0;
+}
+      </programlisting>
     </para>
   </refsect1>
 

--- a/examples/cpu_usage.c
+++ b/examples/cpu_usage.c
@@ -38,10 +38,25 @@ sig_int(int signo) {
 }
 #endif
 
+#ifdef HAVE_LOG4CPLUS_INITIALIZE
+static void *l4cplus_initializer;
+
+static void
+cleanup_logging(void)
+{
+	log4cplus_deinitialize(l4cplus_initializer);
+}
+#endif
+
 int main(int argc, char **argv){
 
 	extern char *optarg;
 	int c;
+
+#ifdef HAVE_LOG4CPLUS_INITIALIZE
+	l4cplus_initializer = log4cplus_initialize();
+	atexit((void (*)(void))cleanup_logging);
+#endif
 
 	int delay = 1;
 	sg_cpu_percents *cpu_percent;

--- a/examples/disk_traffic.c
+++ b/examples/disk_traffic.c
@@ -43,6 +43,16 @@
 
 static int quit;
 
+#ifdef HAVE_LOG4CPLUS_INITIALIZE
+static void *l4cplus_initializer;
+
+static void
+cleanup_logging(void)
+{
+	log4cplus_deinitialize(l4cplus_initializer);
+}
+#endif
+
 int main(int argc, char **argv){
 
 	extern char *optarg;
@@ -55,6 +65,11 @@ int main(int argc, char **argv){
 
 	sg_disk_io_stats *diskio_stats;
 	size_t num_diskio_stats;
+
+#ifdef HAVE_LOG4CPLUS_INITIALIZE
+	l4cplus_initializer = log4cplus_initialize();
+	atexit((void (*)(void))cleanup_logging);
+#endif
 
 	/* Parse command line options */
 	while ((c = getopt(argc, argv, "d:bkm")) != -1){

--- a/examples/filesys_snapshot.c
+++ b/examples/filesys_snapshot.c
@@ -31,9 +31,24 @@
 
 #include "helpers.h"
 
+#ifdef HAVE_LOG4CPLUS_INITIALIZE
+static void *l4cplus_initializer;
+
+static void
+cleanup_logging(void)
+{
+	log4cplus_deinitialize(l4cplus_initializer);
+}
+#endif
+
 int main(int argc, char **argv){
 	sg_fs_stats *fs_stats;
 	size_t fs_size;
+
+#ifdef HAVE_LOG4CPLUS_INITIALIZE
+	l4cplus_initializer = log4cplus_initialize();
+	atexit((void (*)(void))cleanup_logging);
+#endif
 
 	/* Initialise helper - e.g. logging, if any */
 	sg_log_init("libstatgrab-examples", "SGEXAMPLES_LOG_PROPERTIES", argc ? argv[0] : NULL);

--- a/examples/helpers.h
+++ b/examples/helpers.h
@@ -27,6 +27,10 @@
 #include <config.h>
 #endif
 
+#if defined(WITH_LIBLOG4CPLUS)
+#include <log4cplus/clogger.h>
+#endif
+
 #include <signal.h>
 #include <errno.h>
 

--- a/examples/load_stats.c
+++ b/examples/load_stats.c
@@ -29,6 +29,16 @@
 
 static int quit;
 
+#ifdef HAVE_LOG4CPLUS_INITIALIZE
+static void *l4cplus_initializer;
+
+static void
+cleanup_logging(void)
+{
+	log4cplus_deinitialize(l4cplus_initializer);
+}
+#endif
+
 int main(int argc, char **argv){
 
 	extern char *optarg;
@@ -36,6 +46,11 @@ int main(int argc, char **argv){
 
 	int delay = 1;
 	sg_load_stats *load_stat;
+
+#ifdef HAVE_LOG4CPLUS_INITIALIZE
+	l4cplus_initializer = log4cplus_initialize();
+	atexit((void (*)(void))cleanup_logging);
+#endif
 
 	while ((c = getopt(argc, argv, "d:")) != -1){
 		switch (c){

--- a/examples/network_iface_stats.c
+++ b/examples/network_iface_stats.c
@@ -29,10 +29,25 @@
 
 #include "helpers.h"
 
+#ifdef HAVE_LOG4CPLUS_INITIALIZE
+static void *l4cplus_initializer;
+
+static void
+cleanup_logging(void)
+{
+	log4cplus_deinitialize(l4cplus_initializer);
+}
+#endif
+
 int main(int argc, char **argv){
 
 	sg_network_iface_stats *network_iface_stats;
 	size_t iface_count, i;
+
+#ifdef HAVE_LOG4CPLUS_INITIALIZE
+	l4cplus_initializer = log4cplus_initialize();
+	atexit((void (*)(void))cleanup_logging);
+#endif
 
 	/* Initialise helper - e.g. logging, if any */
 	sg_log_init("libstatgrab-examples", "SGEXAMPLES_LOG_PROPERTIES", argc ? argv[0] : NULL);

--- a/examples/network_traffic.c
+++ b/examples/network_traffic.c
@@ -43,6 +43,16 @@
 
 static int quit;
 
+#ifdef HAVE_LOG4CPLUS_INITIALIZE
+static void *l4cplus_initializer;
+
+static void
+cleanup_logging(void)
+{
+	log4cplus_deinitialize(l4cplus_initializer);
+}
+#endif
+
 int main(int argc, char **argv){
 
 	extern char *optarg;
@@ -55,6 +65,11 @@ int main(int argc, char **argv){
 
 	sg_network_io_stats *network_stats;
 	size_t num_network_stats;
+
+#ifdef HAVE_LOG4CPLUS_INITIALIZE
+	l4cplus_initializer = log4cplus_initialize();
+	atexit((void (*)(void))cleanup_logging);
+#endif
 
 	/* Parse command line options */
 	while ((c = getopt(argc, argv, "d:bkm")) != -1){

--- a/examples/os_info.c
+++ b/examples/os_info.c
@@ -38,9 +38,24 @@ static const char *host_states[] = {
 	"hardware virtualization"
 };
 
+#ifdef HAVE_LOG4CPLUS_INITIALIZE
+static void *l4cplus_initializer;
+
+static void
+cleanup_logging(void)
+{
+	log4cplus_deinitialize(l4cplus_initializer);
+}
+#endif
+
 int main(int argc, char **argv){
 
 	sg_host_info *general_stats;
+
+#ifdef HAVE_LOG4CPLUS_INITIALIZE
+	l4cplus_initializer = log4cplus_initialize();
+	atexit((void (*)(void))cleanup_logging);
+#endif
 
 	/* Initialise helper - e.g. logging, if any */
 	sg_log_init("libstatgrab-examples", "SGEXAMPLES_LOG_PROPERTIES", argc ? argv[0] : NULL);

--- a/examples/page_stats.c
+++ b/examples/page_stats.c
@@ -29,6 +29,16 @@
 
 static int quit;
 
+#ifdef HAVE_LOG4CPLUS_INITIALIZE
+static void *l4cplus_initializer;
+
+static void
+cleanup_logging(void)
+{
+	log4cplus_deinitialize(l4cplus_initializer);
+}
+#endif
+
 int main(int argc, char **argv){
 
 	extern char *optarg;
@@ -36,6 +46,11 @@ int main(int argc, char **argv){
 
 	int delay = 1;
 	sg_page_stats *page_stats;
+
+#ifdef HAVE_LOG4CPLUS_INITIALIZE
+	l4cplus_initializer = log4cplus_initialize();
+	atexit((void (*)(void))cleanup_logging);
+#endif
 
 	while ((c = getopt(argc, argv, "d:")) != -1){
 		switch (c){

--- a/examples/process_snapshot.c
+++ b/examples/process_snapshot.c
@@ -27,11 +27,26 @@
 
 #include "helpers.h"
 
+#ifdef HAVE_LOG4CPLUS_INITIALIZE
+static void *l4cplus_initializer;
+
+static void
+cleanup_logging(void)
+{
+	log4cplus_deinitialize(l4cplus_initializer);
+}
+#endif
+
 int main(int argc, char **argv){
 	sg_process_stats *ps;
 	size_t ps_size;
 	size_t x;
 	char *state = NULL;
+
+#ifdef HAVE_LOG4CPLUS_INITIALIZE
+	l4cplus_initializer = log4cplus_initialize();
+	atexit((void (*)(void))cleanup_logging);
+#endif
 
 	/* Initialise helper - e.g. logging, if any */
 	sg_log_init("libstatgrab-examples", "SGEXAMPLES_LOG_PROPERTIES", argc ? argv[0] : NULL);

--- a/examples/process_stats.c
+++ b/examples/process_stats.c
@@ -29,6 +29,16 @@
 
 static int quit;
 
+#ifdef HAVE_LOG4CPLUS_INITIALIZE
+static void *l4cplus_initializer;
+
+static void
+cleanup_logging(void)
+{
+	log4cplus_deinitialize(l4cplus_initializer);
+}
+#endif
+
 int main(int argc, char **argv){
 
 	extern char *optarg;
@@ -36,6 +46,11 @@ int main(int argc, char **argv){
 
 	int delay = 1;
 	sg_process_count *process_stat;
+
+#ifdef HAVE_LOG4CPLUS_INITIALIZE
+	l4cplus_initializer = log4cplus_initialize();
+	atexit((void (*)(void))cleanup_logging);
+#endif
 
 	while ((c = getopt(argc, argv, "d:")) != -1){
 		switch (c){

--- a/examples/user_list.c
+++ b/examples/user_list.c
@@ -27,10 +27,25 @@
 
 #include "helpers.h"
 
+#ifdef HAVE_LOG4CPLUS_INITIALIZE
+static void *l4cplus_initializer;
+
+static void
+cleanup_logging(void)
+{
+	log4cplus_deinitialize(l4cplus_initializer);
+}
+#endif
+
 int main(int argc, char **argv){
 
 	size_t nusers, x;
 	sg_user_stats *users;
+
+#ifdef HAVE_LOG4CPLUS_INITIALIZE
+	l4cplus_initializer = log4cplus_initialize();
+	atexit((void (*)(void))cleanup_logging);
+#endif
 
 #if 0
 	int c;

--- a/examples/valid_filesystems.c
+++ b/examples/valid_filesystems.c
@@ -31,9 +31,24 @@
 
 #include "helpers.h"
 
+#ifdef HAVE_LOG4CPLUS_INITIALIZE
+static void *l4cplus_initializer;
+
+static void
+cleanup_logging(void)
+{
+	log4cplus_deinitialize(l4cplus_initializer);
+}
+#endif
+
 int main(int argc, char **argv) {
 	size_t nvalid_fs = 0;
 	const char **valid_fs;
+
+#ifdef HAVE_LOG4CPLUS_INITIALIZE
+	l4cplus_initializer = log4cplus_initialize();
+	atexit((void (*)(void))cleanup_logging);
+#endif
 
 	/* Initialise helper - e.g. logging, if any */
 	sg_log_init("libstatgrab-examples", "SGEXAMPLES_LOG_PROPERTIES", argc ? argv[0] : NULL);

--- a/examples/vm_stats.c
+++ b/examples/vm_stats.c
@@ -27,12 +27,27 @@
 
 #include "helpers.h"
 
+#ifdef HAVE_LOG4CPLUS_INITIALIZE
+static void *l4cplus_initializer;
+
+static void
+cleanup_logging(void)
+{
+	log4cplus_deinitialize(l4cplus_initializer);
+}
+#endif
+
 int main(int argc, char **argv){
 
 	sg_mem_stats *mem_stats;
 	sg_swap_stats *swap_stats;
 
 	long long total, free;
+
+#ifdef HAVE_LOG4CPLUS_INITIALIZE
+	l4cplus_initializer = log4cplus_initialize();
+	atexit((void (*)(void))cleanup_logging);
+#endif
 
 	/* Initialise helper - e.g. logging, if any */
 	sg_log_init("libstatgrab-examples", "SGEXAMPLES_LOG_PROPERTIES", argc ? argv[0] : NULL);

--- a/libstatgrab-examples.properties
+++ b/libstatgrab-examples.properties
@@ -1,5 +1,7 @@
 log4cplus.logger.statgrab=TRACE, LOGFILE
 
 log4cplus.appender.LOGFILE=log4cplus::FileAppender
-log4cplus.appender.LOGFILE.File=./statgrab.log4cplus
+log4cplus.appender.LOGFILE.File=./examples.log
 log4cplus.appender.LOGFILE.layout=log4cplus::TTCCLayout
+log4cplus.appender.LOGFILE.layout.DateFormat=%FT%T.%q %Z
+log4cplus.appender.LOGFILE.layout.Use_gmtime=false

--- a/saidar.properties.in
+++ b/saidar.properties.in
@@ -1,5 +1,5 @@
 log4cplus.logger.statgrab=TRACE, LOGFILE
 
 log4cplus.appender.LOGFILE=log4cplus::FileAppender
-log4cplus.appender.LOGFILE.File=@localstatedir@/saidar.log4cplus
+log4cplus.appender.LOGFILE.File=@localstatedir@/log/saidar.log4cplus
 log4cplus.appender.LOGFILE.layout=log4cplus::TTCCLayout

--- a/saidar.properties.in
+++ b/saidar.properties.in
@@ -1,5 +1,7 @@
 log4cplus.logger.statgrab=TRACE, LOGFILE
 
 log4cplus.appender.LOGFILE=log4cplus::FileAppender
-log4cplus.appender.LOGFILE.File=@localstatedir@/log/saidar.log4cplus
+log4cplus.appender.LOGFILE.File=@localstatedir@/log/saidar.log
 log4cplus.appender.LOGFILE.layout=log4cplus::TTCCLayout
+log4cplus.appender.LOGFILE.layout.DateFormat=%FT%T.%q %Z
+log4cplus.appender.LOGFILE.layout.Use_gmtime=false

--- a/src/saidar/saidar.c
+++ b/src/saidar/saidar.c
@@ -43,6 +43,10 @@
 #include <sys/termios.h>
 #endif
 
+#if defined(WITH_LIBLOG4CPLUS)
+#include <log4cplus/clogger.h>
+#endif
+
 #ifdef HAVE_NCURSES_H
 #define COLOR_SUPPORT
 #endif
@@ -790,6 +794,16 @@ set_valid_filesystems(char const *fslist) {
 	return SG_ERROR_NONE;
 }
 
+#ifdef HAVE_LOG4CPLUS_INITIALIZE
+static void *l4cplus_initializer;
+
+static void
+cleanup_logging(void)
+{
+	log4cplus_deinitialize(l4cplus_initializer);
+}
+#endif
+
 int main(int argc, char **argv){
 	int c;
 	int colouron = 0;
@@ -802,6 +816,10 @@ int main(int argc, char **argv){
 
 	int delay=2;
 
+#ifdef HAVE_LOG4CPLUS_INITIALIZE
+	l4cplus_initializer = log4cplus_initialize();
+	atexit((void (*)(void))cleanup_logging);
+#endif
 	sg_log_init("saidar", "SAIDAR_LOG_PROPERTIES", argc ? argv[0] : NULL);
 	sg_init(1);
 	if(sg_drop_privileges() != 0){
@@ -913,5 +931,6 @@ int main(int argc, char **argv){
 
 	endwin();
 	sg_shutdown();
+
 	return 0;
 }

--- a/src/statgrab/statgrab.c
+++ b/src/statgrab/statgrab.c
@@ -20,6 +20,10 @@
  * 02110-1301, USA.
  */
 
+#ifdef HAVE_CONFIG_H
+#include "config.h"
+#endif
+
 #include "tools.h"
 
 #include <statgrab.h>
@@ -28,6 +32,10 @@
 #include <stdarg.h>
 #include <stdlib.h>
 #include <unistd.h>
+
+#if defined(WITH_LIBLOG4CPLUS)
+#include <log4cplus/clogger.h>
+#endif
 
 typedef enum {
 	STAT_TYPE_LONG_LONG = 0,
@@ -986,6 +994,16 @@ set_valid_filesystems(char const *fslist) {
 	return SG_ERROR_NONE;
 }
 
+#ifdef HAVE_LOG4CPLUS_INITIALIZE
+static void *l4cplus_initializer;
+
+static void
+cleanup_logging(void)
+{
+	log4cplus_deinitialize(l4cplus_initializer);
+}
+#endif
+
 int
 main(int argc, char **argv) {
 	char *fslist = NULL;
@@ -1079,6 +1097,10 @@ main(int argc, char **argv) {
 
 	select_interesting(argc - optind, &argv[optind]);
 
+#ifdef HAVE_LOG4CPLUS_INITIALIZE
+	l4cplus_initializer = log4cplus_initialize();
+	atexit((void (*)(void))cleanup_logging);
+#endif
 	sg_log_init("statgrab", "STATGRAB_LOG_PROPERTIES", argc ? argv[0] : NULL);
 	/* We don't care if sg_init fails, because we can just display
  	   the statistics that can be read as non-root. */

--- a/statgrab.properties.in
+++ b/statgrab.properties.in
@@ -1,5 +1,7 @@
 log4cplus.logger.statgrab=TRACE, LOGFILE
 
 log4cplus.appender.LOGFILE=log4cplus::FileAppender
-log4cplus.appender.LOGFILE.File=@localstatedir@/log/statgrab.log4cplus
+log4cplus.appender.LOGFILE.File=@localstatedir@/log/statgrab.log
 log4cplus.appender.LOGFILE.layout=log4cplus::TTCCLayout
+log4cplus.appender.LOGFILE.layout.DateFormat=%FT%T.%q %Z
+log4cplus.appender.LOGFILE.layout.Use_gmtime=false

--- a/statgrab.properties.in
+++ b/statgrab.properties.in
@@ -1,5 +1,5 @@
 log4cplus.logger.statgrab=TRACE, LOGFILE
 
 log4cplus.appender.LOGFILE=log4cplus::FileAppender
-log4cplus.appender.LOGFILE.File=@localstatedir@/statgrab.log4cplus
+log4cplus.appender.LOGFILE.File=@localstatedir@/log/statgrab.log4cplus
 log4cplus.appender.LOGFILE.layout=log4cplus::TTCCLayout

--- a/tests/multi_threaded/diff_stats.c
+++ b/tests/multi_threaded/diff_stats.c
@@ -23,6 +23,14 @@
 #include <tools.h>
 #include <testlib.h>
 
+#ifdef HAVE_CONFIG_H
+#include <config.h>
+#endif
+
+#if defined(WITH_LIBLOG4CPLUS)
+#include <log4cplus/clogger.h>
+#endif
+
 static void
 prove_libcall(char *libcall, int err_code)
 {
@@ -109,8 +117,23 @@ help(char *prgname) {
 		"\t-s\tsequencial calling of test functions\n", prgname );
 }
 
+#ifdef HAVE_LOG4CPLUS_INITIALIZE
+static void *l4cplus_initializer;
+
+static void
+cleanup_logging(void)
+{
+	log4cplus_deinitialize(l4cplus_initializer);
+}
+#endif
+
 int
 main(int argc, char **argv) {
+#ifdef HAVE_LOG4CPLUS_INITIALIZE
+	l4cplus_initializer = log4cplus_initialize();
+	atexit((void (*)(void))cleanup_logging);
+#endif
+
 	sg_log_init("libstatgrab-test", "SGTEST_LOG_PROPERTIES", argc ? argv[0] : NULL);
 	sg_init(1);
 

--- a/tests/multi_threaded/full_stats.c
+++ b/tests/multi_threaded/full_stats.c
@@ -23,6 +23,14 @@
 #include <tools.h>
 #include <testlib.h>
 
+#ifdef HAVE_CONFIG_H
+#include <config.h>
+#endif
+
+#if defined(WITH_LIBLOG4CPLUS)
+#include <log4cplus/clogger.h>
+#endif
+
 static void
 prove_libcall(char *libcall, int err_code)
 {
@@ -109,8 +117,23 @@ help(char *prgname) {
 		"\t-s\tsequencial calling of test functions\n", prgname );
 }
 
+#ifdef HAVE_LOG4CPLUS_INITIALIZE
+static void *l4cplus_initializer;
+
+static void
+cleanup_logging(void)
+{
+	log4cplus_deinitialize(l4cplus_initializer);
+}
+#endif
+
 int
 main(int argc, char **argv) {
+#ifdef HAVE_LOG4CPLUS_INITIALIZE
+	l4cplus_initializer = log4cplus_initialize();
+	atexit((void (*)(void))cleanup_logging);
+#endif
+
 	sg_log_init("libstatgrab-test", "SGTEST_LOG_PROPERTIES", argc ? argv[0] : NULL);
 	sg_init(1);
 

--- a/tests/multi_threaded/libstatgrab-test.properties
+++ b/tests/multi_threaded/libstatgrab-test.properties
@@ -1,6 +1,8 @@
 log4cplus.logger.statgrab=TRACE, LOGFILE
 
 log4cplus.appender.LOGFILE=log4cplus::FileAppender
-log4cplus.appender.LOGFILE.File=./statgrab.log4cplus
+log4cplus.appender.LOGFILE.File=./st-test.log
 log4cplus.appender.LOGFILE.Append=true
 log4cplus.appender.LOGFILE.layout=log4cplus::TTCCLayout
+log4cplus.appender.LOGFILE.layout.DateFormat=%FT%T.%q %Z
+log4cplus.appender.LOGFILE.layout.Use_gmtime=false

--- a/tests/single_threaded/diff_stats.c
+++ b/tests/single_threaded/diff_stats.c
@@ -23,6 +23,14 @@
 #include <tools.h>
 #include <testlib.h>
 
+#ifdef HAVE_CONFIG_H
+#include <config.h>
+#endif
+
+#if defined(WITH_LIBLOG4CPLUS)
+#include <log4cplus/clogger.h>
+#endif
+
 #define NLOOPS 1
 
 struct opt_def opt_def[] = {
@@ -47,8 +55,23 @@ help(char *prgname) {
 		"\t-n\tnumber of loops to run (must be greater or equal to 1)\n", prgname );
 }
 
+#ifdef HAVE_LOG4CPLUS_INITIALIZE
+static void *l4cplus_initializer;
+
+static void
+cleanup_logging(void)
+{
+	log4cplus_deinitialize(l4cplus_initializer);
+}
+#endif
+
 int
 main(int argc, char **argv) {
+#ifdef HAVE_LOG4CPLUS_INITIALIZE
+	l4cplus_initializer = log4cplus_initialize();
+	atexit((void (*)(void))cleanup_logging);
+#endif
+
 	sg_log_init("libstatgrab-test", "SGTEST_LOG_PROPERTIES", argc ? argv[0] : NULL);
 	sg_init(1);
 

--- a/tests/single_threaded/full_stats.c
+++ b/tests/single_threaded/full_stats.c
@@ -23,6 +23,14 @@
 #include <tools.h>
 #include <testlib.h>
 
+#ifdef HAVE_CONFIG_H
+#include <config.h>
+#endif
+
+#if defined(WITH_LIBLOG4CPLUS)
+#include <log4cplus/clogger.h>
+#endif
+
 #define NLOOPS 1
 
 struct opt_def opt_def[] = {
@@ -47,8 +55,23 @@ help(char *prgname) {
 		"\t-n\tnumber of loops to run (must be greater or equal to 1)\n", prgname );
 }
 
+#ifdef HAVE_LOG4CPLUS_INITIALIZE
+static void *l4cplus_initializer;
+
+static void
+cleanup_logging(void)
+{
+	log4cplus_deinitialize(l4cplus_initializer);
+}
+#endif
+
 int
 main(int argc, char **argv) {
+#ifdef HAVE_LOG4CPLUS_INITIALIZE
+	l4cplus_initializer = log4cplus_initialize();
+	atexit((void (*)(void))cleanup_logging);
+#endif
+
 	sg_log_init("libstatgrab-test", "SGTEST_LOG_PROPERTIES", argc ? argv[0] : NULL);
 	sg_init(1);
 

--- a/tests/single_threaded/libstatgrab-test.properties
+++ b/tests/single_threaded/libstatgrab-test.properties
@@ -1,6 +1,8 @@
 log4cplus.logger.statgrab=TRACE, LOGFILE
 
 log4cplus.appender.LOGFILE=log4cplus::FileAppender
-log4cplus.appender.LOGFILE.File=./statgrab.log4cplus
+log4cplus.appender.LOGFILE.File=./mt-test.log
 log4cplus.appender.LOGFILE.Append=true
 log4cplus.appender.LOGFILE.layout=log4cplus::TTCCLayout
+log4cplus.appender.LOGFILE.layout.DateFormat=%FT%T.%q %Z
+log4cplus.appender.LOGFILE.layout.Use_gmtime=false


### PR DESCRIPTION
With log4cplus 2.x, using applications are encouraged to initialize and
deinitialize the log library appropriately.

Since libstatgrab removes its own global used memory during atexit(3)
phase, register logging deinitialization before sg_init(3) is called -
atexit hooks are usually executed in reverse order.

Maybe this should be mentioned somewhere ...

Signed-off-by: Jens Rehsack <sno@netbsd.org>