### PR TITLE
Update copyright notices

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -1,6 +1,9 @@
 # libstatgrab CI
 #
-# Copyright (C) 2019 Tim Bishop
+# Copyright (C) 2003-2004 Peter Saunders
+# Copyright (C) 2003-2019 Tim Bishop
+# Copyright (C) 2003-2013 Adam Sampson
+# Copyright (C) 2012-2019 Jens Rehsack
 #
 # The distfile stage builds a tarball that matches a release tarball.
 # This allows subsequent stages to test libstatgrab as end users will

--- a/examples/cpu_usage.c
+++ b/examples/cpu_usage.c
@@ -1,8 +1,10 @@
 /*
  * libstatgrab
  * https://libstatgrab.org
- * Copyright (C) 2000-2013 i-scream
- * Copyright (C) 2010-2013 Jens Rehsack
+ * Copyright (C) 2003-2004 Peter Saunders
+ * Copyright (C) 2003-2019 Tim Bishop
+ * Copyright (C) 2003-2013 Adam Sampson
+ * Copyright (C) 2012-2019 Jens Rehsack
  *
  * This program is free software; you can redistribute it and/or
  * modify it under the terms of the GNU General Public License

--- a/examples/disk_traffic.c
+++ b/examples/disk_traffic.c
@@ -1,8 +1,10 @@
 /*
  * libstatgrab
  * https://libstatgrab.org
- * Copyright (C) 2000-2013 i-scream
- * Copyright (C) 2010-2013 Jens Rehsack
+ * Copyright (C) 2003-2004 Peter Saunders
+ * Copyright (C) 2003-2019 Tim Bishop
+ * Copyright (C) 2003-2013 Adam Sampson
+ * Copyright (C) 2012-2019 Jens Rehsack
  *
  * This program is free software; you can redistribute it and/or
  * modify it under the terms of the GNU General Public License

--- a/examples/filesys_snapshot.c
+++ b/examples/filesys_snapshot.c
@@ -1,8 +1,10 @@
 /*
  * libstatgrab
  * https://libstatgrab.org
- * Copyright (C) 2000-2013 i-scream
- * Copyright (C) 2010-2013 Jens Rehsack
+ * Copyright (C) 2003-2004 Peter Saunders
+ * Copyright (C) 2003-2019 Tim Bishop
+ * Copyright (C) 2003-2013 Adam Sampson
+ * Copyright (C) 2012-2019 Jens Rehsack
  *
  * This program is free software; you can redistribute it and/or
  * modify it under the terms of the GNU General Public License

--- a/examples/helpers.c
+++ b/examples/helpers.c
@@ -1,8 +1,10 @@
 /*
  * libstatgrab
  * https://libstatgrab.org
- * Copyright (C) 2000-2013 i-scream
- * Copyright (C) 2010-2013 Jens Rehsack
+ * Copyright (C) 2003-2004 Peter Saunders
+ * Copyright (C) 2003-2019 Tim Bishop
+ * Copyright (C) 2003-2013 Adam Sampson
+ * Copyright (C) 2012-2019 Jens Rehsack
  *
  * This program is free software; you can redistribute it and/or
  * modify it under the terms of the GNU General Public License

--- a/examples/helpers.h
+++ b/examples/helpers.h
@@ -1,8 +1,10 @@
 /*
  * libstatgrab
  * https://libstatgrab.org
- * Copyright (C) 2000-2013 i-scream
- * Copyright (C) 2010-2013 Jens Rehsack
+ * Copyright (C) 2003-2004 Peter Saunders
+ * Copyright (C) 2003-2019 Tim Bishop
+ * Copyright (C) 2003-2013 Adam Sampson
+ * Copyright (C) 2012-2019 Jens Rehsack
  *
  * This program is free software; you can redistribute it and/or
  * modify it under the terms of the GNU General Public License

--- a/examples/load_stats.c
+++ b/examples/load_stats.c
@@ -1,8 +1,10 @@
 /*
  * libstatgrab
  * https://libstatgrab.org
- * Copyright (C) 2000-2013 i-scream
- * Copyright (C) 2010-2013 Jens Rehsack
+ * Copyright (C) 2003-2004 Peter Saunders
+ * Copyright (C) 2003-2019 Tim Bishop
+ * Copyright (C) 2003-2013 Adam Sampson
+ * Copyright (C) 2012-2019 Jens Rehsack
  *
  * This program is free software; you can redistribute it and/or
  * modify it under the terms of the GNU General Public License

--- a/examples/network_iface_stats.c
+++ b/examples/network_iface_stats.c
@@ -1,8 +1,10 @@
 /*
  * libstatgrab
  * https://libstatgrab.org
- * Copyright (C) 2000-2013 i-scream
- * Copyright (C) 2010-2013 Jens Rehsack
+ * Copyright (C) 2003-2004 Peter Saunders
+ * Copyright (C) 2003-2019 Tim Bishop
+ * Copyright (C) 2003-2013 Adam Sampson
+ * Copyright (C) 2012-2019 Jens Rehsack
  *
  * This program is free software; you can redistribute it and/or
  * modify it under the terms of the GNU General Public License

--- a/examples/network_traffic.c
+++ b/examples/network_traffic.c
@@ -1,8 +1,10 @@
 /*
  * libstatgrab
  * https://libstatgrab.org
- * Copyright (C) 2000-2013 i-scream
- * Copyright (C) 2010-2013 Jens Rehsack
+ * Copyright (C) 2003-2004 Peter Saunders
+ * Copyright (C) 2003-2019 Tim Bishop
+ * Copyright (C) 2003-2013 Adam Sampson
+ * Copyright (C) 2012-2019 Jens Rehsack
  *
  * This program is free software; you can redistribute it and/or
  * modify it under the terms of the GNU General Public License

--- a/examples/os_info.c
+++ b/examples/os_info.c
@@ -1,8 +1,10 @@
 /*
  * libstatgrab
  * https://libstatgrab.org
- * Copyright (C) 2000-2013 i-scream
- * Copyright (C) 2010-2013 Jens Rehsack
+ * Copyright (C) 2003-2004 Peter Saunders
+ * Copyright (C) 2003-2019 Tim Bishop
+ * Copyright (C) 2003-2013 Adam Sampson
+ * Copyright (C) 2012-2019 Jens Rehsack
  *
  * This program is free software; you can redistribute it and/or
  * modify it under the terms of the GNU General Public License

--- a/examples/page_stats.c
+++ b/examples/page_stats.c
@@ -1,8 +1,10 @@
 /*
  * libstatgrab
  * https://libstatgrab.org
- * Copyright (C) 2000-2013 i-scream
- * Copyright (C) 2010-2013 Jens Rehsack
+ * Copyright (C) 2003-2004 Peter Saunders
+ * Copyright (C) 2003-2019 Tim Bishop
+ * Copyright (C) 2003-2013 Adam Sampson
+ * Copyright (C) 2012-2019 Jens Rehsack
  *
  * This program is free software; you can redistribute it and/or
  * modify it under the terms of the GNU General Public License

--- a/examples/process_snapshot.c
+++ b/examples/process_snapshot.c
@@ -1,8 +1,10 @@
 /*
  * libstatgrab
  * https://libstatgrab.org
- * Copyright (C) 2000-2013 i-scream
- * Copyright (C) 2010-2013 Jens Rehsack
+ * Copyright (C) 2003-2004 Peter Saunders
+ * Copyright (C) 2003-2019 Tim Bishop
+ * Copyright (C) 2003-2013 Adam Sampson
+ * Copyright (C) 2012-2019 Jens Rehsack
  *
  * This program is free software; you can redistribute it and/or
  * modify it under the terms of the GNU General Public License

--- a/examples/process_stats.c
+++ b/examples/process_stats.c
@@ -1,8 +1,10 @@
 /*
  * libstatgrab
  * https://libstatgrab.org
- * Copyright (C) 2000-2013 i-scream
- * Copyright (C) 2010-2013 Jens Rehsack
+ * Copyright (C) 2003-2004 Peter Saunders
+ * Copyright (C) 2003-2019 Tim Bishop
+ * Copyright (C) 2003-2013 Adam Sampson
+ * Copyright (C) 2012-2019 Jens Rehsack
  *
  * This program is free software; you can redistribute it and/or
  * modify it under the terms of the GNU General Public License

--- a/examples/user_list.c
+++ b/examples/user_list.c
@@ -1,8 +1,10 @@
 /*
  * libstatgrab
  * https://libstatgrab.org
- * Copyright (C) 2000-2013 i-scream
- * Copyright (C) 2010-2013 Jens Rehsack
+ * Copyright (C) 2003-2004 Peter Saunders
+ * Copyright (C) 2003-2019 Tim Bishop
+ * Copyright (C) 2003-2013 Adam Sampson
+ * Copyright (C) 2012-2019 Jens Rehsack
  *
  * This program is free software; you can redistribute it and/or
  * modify it under the terms of the GNU General Public License

--- a/examples/valid_filesystems.c
+++ b/examples/valid_filesystems.c
@@ -1,8 +1,10 @@
 /*
  * libstatgrab
  * https://libstatgrab.org
- * Copyright (C) 2011-2013 i-scream
- * Copyright (C) 2011-2013 Jens Rehsack
+ * Copyright (C) 2003-2004 Peter Saunders
+ * Copyright (C) 2003-2019 Tim Bishop
+ * Copyright (C) 2003-2013 Adam Sampson
+ * Copyright (C) 2012-2019 Jens Rehsack
  *
  * This program is free software; you can redistribute it and/or
  * modify it under the terms of the GNU General Public License

--- a/examples/vm_stats.c
+++ b/examples/vm_stats.c
@@ -1,8 +1,10 @@
 /*
  * libstatgrab
  * https://libstatgrab.org
- * Copyright (C) 2000-2013 i-scream
- * Copyright (C) 2010-2013 Jens Rehsack
+ * Copyright (C) 2003-2004 Peter Saunders
+ * Copyright (C) 2003-2019 Tim Bishop
+ * Copyright (C) 2003-2013 Adam Sampson
+ * Copyright (C) 2012-2019 Jens Rehsack
  *
  * This program is free software; you can redistribute it and/or
  * modify it under the terms of the GNU General Public License

--- a/src/libstatgrab/cpu_stats.c
+++ b/src/libstatgrab/cpu_stats.c
@@ -1,8 +1,10 @@
 /*
  * libstatgrab
  * https://libstatgrab.org
- * Copyright (C) 2000-2013 i-scream
- * Copyright (C) 2010-2013 Jens Rehsack
+ * Copyright (C) 2003-2004 Peter Saunders
+ * Copyright (C) 2003-2019 Tim Bishop
+ * Copyright (C) 2003-2013 Adam Sampson
+ * Copyright (C) 2012-2019 Jens Rehsack
  * 
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public

--- a/src/libstatgrab/disk_stats.c
+++ b/src/libstatgrab/disk_stats.c
@@ -1,8 +1,10 @@
 /*
  * libstatgrab
  * https://libstatgrab.org
- * Copyright (C) 2000-2013 i-scream
- * Copyright (C) 2010-2013 Jens Rehsack
+ * Copyright (C) 2003-2004 Peter Saunders
+ * Copyright (C) 2003-2019 Tim Bishop
+ * Copyright (C) 2003-2013 Adam Sampson
+ * Copyright (C) 2012-2019 Jens Rehsack
  * 
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public

--- a/src/libstatgrab/error.c
+++ b/src/libstatgrab/error.c
@@ -1,8 +1,10 @@
 /*
  * libstatgrab
  * https://libstatgrab.org
- * Copyright (C) 2000-2013 i-scream
- * Copyright (C) 2010-2013 Jens Rehsack
+ * Copyright (C) 2003-2004 Peter Saunders
+ * Copyright (C) 2003-2019 Tim Bishop
+ * Copyright (C) 2003-2013 Adam Sampson
+ * Copyright (C) 2012-2019 Jens Rehsack
  * 
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public

--- a/src/libstatgrab/error.h
+++ b/src/libstatgrab/error.h
@@ -1,8 +1,10 @@
 /*
  * libstatgrab
  * https://libstatgrab.org
- * Copyright (C) 2000-2013 i-scream
- * Copyright (C) 2010-2013 Jens Rehsack
+ * Copyright (C) 2003-2004 Peter Saunders
+ * Copyright (C) 2003-2019 Tim Bishop
+ * Copyright (C) 2003-2013 Adam Sampson
+ * Copyright (C) 2012-2019 Jens Rehsack
  * 
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public

--- a/src/libstatgrab/globals.c
+++ b/src/libstatgrab/globals.c
@@ -1,8 +1,10 @@
 /*
  * libstatgrab
  * https://libstatgrab.org
- * Copyright (C) 2000-2013 i-scream
- * Copyright (C) 2010-2013 Jens Rehsack
+ * Copyright (C) 2003-2004 Peter Saunders
+ * Copyright (C) 2003-2019 Tim Bishop
+ * Copyright (C) 2003-2013 Adam Sampson
+ * Copyright (C) 2012-2019 Jens Rehsack
  * 
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public

--- a/src/libstatgrab/globals.h
+++ b/src/libstatgrab/globals.h
@@ -1,8 +1,10 @@
 /*
  * libstatgrab
  * https://libstatgrab.org
- * Copyright (C) 2000-2013 i-scream
- * Copyright (C) 2010-2013 Jens Rehsack
+ * Copyright (C) 2003-2004 Peter Saunders
+ * Copyright (C) 2003-2019 Tim Bishop
+ * Copyright (C) 2003-2013 Adam Sampson
+ * Copyright (C) 2012-2019 Jens Rehsack
  * 
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public

--- a/src/libstatgrab/load_stats.c
+++ b/src/libstatgrab/load_stats.c
@@ -1,8 +1,10 @@
 /*
  * libstatgrab
  * https://libstatgrab.org
- * Copyright (C) 2000-2013 i-scream
- * Copyright (C) 2010-2013 Jens Rehsack
+ * Copyright (C) 2003-2004 Peter Saunders
+ * Copyright (C) 2003-2019 Tim Bishop
+ * Copyright (C) 2003-2013 Adam Sampson
+ * Copyright (C) 2012-2019 Jens Rehsack
  * 
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public

--- a/src/libstatgrab/memory_stats.c
+++ b/src/libstatgrab/memory_stats.c
@@ -1,8 +1,10 @@
 /*
  * libstatgrab
  * https://libstatgrab.org
- * Copyright (C) 2000-2013 i-scream
- * Copyright (C) 2010-2013 Jens Rehsack
+ * Copyright (C) 2003-2004 Peter Saunders
+ * Copyright (C) 2003-2019 Tim Bishop
+ * Copyright (C) 2003-2013 Adam Sampson
+ * Copyright (C) 2012-2019 Jens Rehsack
  * 
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public

--- a/src/libstatgrab/network_stats.c
+++ b/src/libstatgrab/network_stats.c
@@ -1,8 +1,10 @@
 /*
  * libstatgrab
  * https://libstatgrab.org
- * Copyright (C) 2000-2013 i-scream
- * Copyright (C) 2010-2013 Jens Rehsack
+ * Copyright (C) 2003-2004 Peter Saunders
+ * Copyright (C) 2003-2019 Tim Bishop
+ * Copyright (C) 2003-2013 Adam Sampson
+ * Copyright (C) 2012-2019 Jens Rehsack
  * 
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public

--- a/src/libstatgrab/os_info.c
+++ b/src/libstatgrab/os_info.c
@@ -1,8 +1,10 @@
 /*
  * libstatgrab
  * https://libstatgrab.org
- * Copyright (C) 2000-2013 i-scream
- * Copyright (C) 2010-2013 Jens Rehsack
+ * Copyright (C) 2003-2004 Peter Saunders
+ * Copyright (C) 2003-2019 Tim Bishop
+ * Copyright (C) 2003-2013 Adam Sampson
+ * Copyright (C) 2012-2019 Jens Rehsack
  * 
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public

--- a/src/libstatgrab/page_stats.c
+++ b/src/libstatgrab/page_stats.c
@@ -1,8 +1,10 @@
 /*
  * libstatgrab
  * https://libstatgrab.org
- * Copyright (C) 2000-2013 i-scream
- * Copyright (C) 2010-2013 Jens Rehsack
+ * Copyright (C) 2003-2004 Peter Saunders
+ * Copyright (C) 2003-2019 Tim Bishop
+ * Copyright (C) 2003-2013 Adam Sampson
+ * Copyright (C) 2012-2019 Jens Rehsack
  * 
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public

--- a/src/libstatgrab/process_stats.c
+++ b/src/libstatgrab/process_stats.c
@@ -1,8 +1,10 @@
 /*
  * libstatgrab
  * https://libstatgrab.org
- * Copyright (C) 2000-2013 i-scream
- * Copyright (C) 2010-2013 Jens Rehsack
+ * Copyright (C) 2003-2004 Peter Saunders
+ * Copyright (C) 2003-2019 Tim Bishop
+ * Copyright (C) 2003-2013 Adam Sampson
+ * Copyright (C) 2012-2019 Jens Rehsack
  * 
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public

--- a/src/libstatgrab/statgrab.h.in
+++ b/src/libstatgrab/statgrab.h.in
@@ -1,8 +1,10 @@
 /*
  * libstatgrab
  * https://libstatgrab.org
- * Copyright (C) 2000-2013 i-scream
- * Copyright (C) 2010-2013 Jens Rehsack
+ * Copyright (C) 2003-2004 Peter Saunders
+ * Copyright (C) 2003-2019 Tim Bishop
+ * Copyright (C) 2003-2013 Adam Sampson
+ * Copyright (C) 2012-2019 Jens Rehsack
  * 
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public

--- a/src/libstatgrab/swap_stats.c
+++ b/src/libstatgrab/swap_stats.c
@@ -1,8 +1,10 @@
 /*
  * libstatgrab
  * https://libstatgrab.org
- * Copyright (C) 2000-2013 i-scream
- * Copyright (C) 2010-2013 Jens Rehsack
+ * Copyright (C) 2003-2004 Peter Saunders
+ * Copyright (C) 2003-2019 Tim Bishop
+ * Copyright (C) 2003-2013 Adam Sampson
+ * Copyright (C) 2012-2019 Jens Rehsack
  * 
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public

--- a/src/libstatgrab/tools.c
+++ b/src/libstatgrab/tools.c
@@ -1,8 +1,10 @@
 /*
  * libstatgrab
  * https://libstatgrab.org
- * Copyright (C) 2000-2013 i-scream
- * Copyright (C) 2010-2013 Jens Rehsack
+ * Copyright (C) 2003-2004 Peter Saunders
+ * Copyright (C) 2003-2019 Tim Bishop
+ * Copyright (C) 2003-2013 Adam Sampson
+ * Copyright (C) 2012-2019 Jens Rehsack
  * 
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public

--- a/src/libstatgrab/tools.h
+++ b/src/libstatgrab/tools.h
@@ -1,8 +1,10 @@
 /*
  * libstatgrab
  * https://libstatgrab.org
- * Copyright (C) 2000-2013 i-scream
- * Copyright (C) 2010-2013 Jens Rehsack
+ * Copyright (C) 2003-2004 Peter Saunders
+ * Copyright (C) 2003-2019 Tim Bishop
+ * Copyright (C) 2003-2013 Adam Sampson
+ * Copyright (C) 2012-2019 Jens Rehsack
  * 
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public

--- a/src/libstatgrab/trace.h
+++ b/src/libstatgrab/trace.h
@@ -1,7 +1,10 @@
 /*
  * libstatgrab
  * https://libstatgrab.org
- * Copyright (C) 2010-2013 Jens Rehsack
+ * Copyright (C) 2003-2004 Peter Saunders
+ * Copyright (C) 2003-2019 Tim Bishop
+ * Copyright (C) 2003-2013 Adam Sampson
+ * Copyright (C) 2012-2019 Jens Rehsack
  * 
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public

--- a/src/libstatgrab/user_stats.c
+++ b/src/libstatgrab/user_stats.c
@@ -1,8 +1,10 @@
 /*
  * libstatgrab
  * https://libstatgrab.org
- * Copyright (C) 2000-2013 i-scream
- * Copyright (C) 2010-2013 Jens Rehsack
+ * Copyright (C) 2003-2004 Peter Saunders
+ * Copyright (C) 2003-2019 Tim Bishop
+ * Copyright (C) 2003-2013 Adam Sampson
+ * Copyright (C) 2012-2019 Jens Rehsack
  * 
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public

--- a/src/libstatgrab/vector.c
+++ b/src/libstatgrab/vector.c
@@ -1,8 +1,10 @@
 /*
  * libstatgrab
  * https://libstatgrab.org
- * Copyright (C) 2000-2013 i-scream
- * Copyright (C) 2010-2013 Jens Rehsack
+ * Copyright (C) 2003-2004 Peter Saunders
+ * Copyright (C) 2003-2019 Tim Bishop
+ * Copyright (C) 2003-2013 Adam Sampson
+ * Copyright (C) 2012-2019 Jens Rehsack
  * 
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public

--- a/src/libstatgrab/vector.h
+++ b/src/libstatgrab/vector.h
@@ -1,8 +1,10 @@
 /*
  * libstatgrab
  * https://libstatgrab.org
- * Copyright (C) 2000-2013 i-scream
- * Copyright (C) 2010-2013 Jens Rehsack
+ * Copyright (C) 2003-2004 Peter Saunders
+ * Copyright (C) 2003-2019 Tim Bishop
+ * Copyright (C) 2003-2013 Adam Sampson
+ * Copyright (C) 2012-2019 Jens Rehsack
  * 
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public

--- a/src/saidar/saidar.c
+++ b/src/saidar/saidar.c
@@ -1,8 +1,10 @@
 /*
  * libstatgrab
  * https://libstatgrab.org
- * Copyright (C) 2000-2013 i-scream
- * Copyright (C) 2010-2013 Jens Rehsack
+ * Copyright (C) 2003-2004 Peter Saunders
+ * Copyright (C) 2003-2019 Tim Bishop
+ * Copyright (C) 2003-2013 Adam Sampson
+ * Copyright (C) 2012-2019 Jens Rehsack
  *
  * This program is free software; you can redistribute it and/or
  * modify it under the terms of the GNU General Public License

--- a/src/statgrab/statgrab-make-mrtg-config.in
+++ b/src/statgrab/statgrab-make-mrtg-config.in
@@ -2,7 +2,10 @@
 
 # libstatgrab
 # https://libstatgrab.org
-# Copyright (C) 2000-2013 i-scream
+# Copyright (C) 2003-2004 Peter Saunders
+# Copyright (C) 2003-2019 Tim Bishop
+# Copyright (C) 2003-2013 Adam Sampson
+# Copyright (C) 2012-2019 Jens Rehsack
 # 
 # This program is free software; you can redistribute it and/or
 # modify it under the terms of the GNU General Public License

--- a/src/statgrab/statgrab-make-mrtg-index.in
+++ b/src/statgrab/statgrab-make-mrtg-index.in
@@ -2,7 +2,10 @@
 
 # libstatgrab
 # https://libstatgrab.org
-# Copyright (C) 2000-2013 i-scream
+# Copyright (C) 2003-2004 Peter Saunders
+# Copyright (C) 2003-2019 Tim Bishop
+# Copyright (C) 2003-2013 Adam Sampson
+# Copyright (C) 2012-2019 Jens Rehsack
 # 
 # This program is free software; you can redistribute it and/or
 # modify it under the terms of the GNU General Public License

--- a/src/statgrab/statgrab.c
+++ b/src/statgrab/statgrab.c
@@ -1,8 +1,10 @@
 /*
  * libstatgrab
  * https://libstatgrab.org
- * Copyright (C) 2000-2013 i-scream
- * Copyright (C) 2010-2013 Jens Rehsack
+ * Copyright (C) 2003-2004 Peter Saunders
+ * Copyright (C) 2003-2019 Tim Bishop
+ * Copyright (C) 2003-2013 Adam Sampson
+ * Copyright (C) 2012-2019 Jens Rehsack
  * 
  * This program is free software; you can redistribute it and/or
  * modify it under the terms of the GNU General Public License

--- a/tests/multi_threaded/diff_stats.c
+++ b/tests/multi_threaded/diff_stats.c
@@ -1,8 +1,10 @@
 /*
  * libstatgrab
  * https://libstatgrab.org
- * Copyright (C) 2010-2013 i-scream
- * Copyright (C) 2010-2013 Jens Rehsack
+ * Copyright (C) 2003-2004 Peter Saunders
+ * Copyright (C) 2003-2019 Tim Bishop
+ * Copyright (C) 2003-2013 Adam Sampson
+ * Copyright (C) 2012-2019 Jens Rehsack
  * 
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public

--- a/tests/multi_threaded/full_stats.c
+++ b/tests/multi_threaded/full_stats.c
@@ -1,8 +1,10 @@
 /*
  * libstatgrab
  * https://libstatgrab.org
- * Copyright (C) 2010-2013 i-scream
- * Copyright (C) 2010-2013 Jens Rehsack
+ * Copyright (C) 2003-2004 Peter Saunders
+ * Copyright (C) 2003-2019 Tim Bishop
+ * Copyright (C) 2003-2013 Adam Sampson
+ * Copyright (C) 2012-2019 Jens Rehsack
  * 
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public

--- a/tests/single_threaded/diff_stats.c
+++ b/tests/single_threaded/diff_stats.c
@@ -1,8 +1,10 @@
 /*
  * libstatgrab
  * https://libstatgrab.org
- * Copyright (C) 2010-2013 i-scream
- * Copyright (C) 2010-2013 Jens Rehsack
+ * Copyright (C) 2003-2004 Peter Saunders
+ * Copyright (C) 2003-2019 Tim Bishop
+ * Copyright (C) 2003-2013 Adam Sampson
+ * Copyright (C) 2012-2019 Jens Rehsack
  * 
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public

--- a/tests/single_threaded/full_stats.c
+++ b/tests/single_threaded/full_stats.c
@@ -1,8 +1,10 @@
 /*
  * libstatgrab
  * https://libstatgrab.org
- * Copyright (C) 2010-2013 i-scream
- * Copyright (C) 2010-2013 Jens Rehsack
+ * Copyright (C) 2003-2004 Peter Saunders
+ * Copyright (C) 2003-2019 Tim Bishop
+ * Copyright (C) 2003-2013 Adam Sampson
+ * Copyright (C) 2012-2019 Jens Rehsack
  * 
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public

--- a/tests/testlib/err.c
+++ b/tests/testlib/err.c
@@ -1,8 +1,10 @@
 /*
  * libstatgrab
  * https://libstatgrab.org
- * Copyright (C) 2010-2013 i-scream
- * Copyright (C) 2010-2013 Jens Rehsack
+ * Copyright (C) 2003-2004 Peter Saunders
+ * Copyright (C) 2003-2019 Tim Bishop
+ * Copyright (C) 2003-2013 Adam Sampson
+ * Copyright (C) 2012-2019 Jens Rehsack
  * 
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public

--- a/tests/testlib/opt.c
+++ b/tests/testlib/opt.c
@@ -1,8 +1,10 @@
 /*
  * libstatgrab
  * https://libstatgrab.org
- * Copyright (C) 2010-2013 i-scream
- * Copyright (C) 2010-2013 Jens Rehsack
+ * Copyright (C) 2003-2004 Peter Saunders
+ * Copyright (C) 2003-2019 Tim Bishop
+ * Copyright (C) 2003-2013 Adam Sampson
+ * Copyright (C) 2012-2019 Jens Rehsack
  * 
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public

--- a/tests/testlib/routines.c
+++ b/tests/testlib/routines.c
@@ -1,8 +1,10 @@
 /*
  * libstatgrab
  * https://libstatgrab.org
- * Copyright (C) 2010-2013 i-scream
- * Copyright (C) 2010-2013 Jens Rehsack
+ * Copyright (C) 2003-2004 Peter Saunders
+ * Copyright (C) 2003-2019 Tim Bishop
+ * Copyright (C) 2003-2013 Adam Sampson
+ * Copyright (C) 2012-2019 Jens Rehsack
  * 
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public

--- a/tests/testlib/testlib.h
+++ b/tests/testlib/testlib.h
@@ -1,8 +1,10 @@
 /*
  * libstatgrab
  * https://libstatgrab.org
- * Copyright (C) 2010-2013 i-scream
- * Copyright (C) 2010-2013 Jens Rehsack
+ * Copyright (C) 2003-2004 Peter Saunders
+ * Copyright (C) 2003-2019 Tim Bishop
+ * Copyright (C) 2003-2013 Adam Sampson
+ * Copyright (C) 2012-2019 Jens Rehsack
  * 
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public


### PR DESCRIPTION
This unrolls the "i-scream" name, which was never really a concrete entity, in to the individual names of the authors involved. It gives correct attribution based on contribution to the overall project and is the same in every file.

Note that I opted for a first-last date range, rather than "year1, year2, year3". This seemed tidier but both are possible.

Closes #113.
