### PR TITLE
Fix build/install of manpages.

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -1562,9 +1562,13 @@ AC_ARG_ENABLE(man,
 	]
 )
 
-AM_CONDITIONAL(MANPAGES, false)
+AM_CONDITIONAL(BUILD_MANPAGES, false)
+AM_CONDITIONAL(MANPAGES, true)
 AS_IF(	[test "x${ENABLE_BUILD_MANPAGES}" = "xno"],
-	[AM_CONDITIONAL(MANPAGES, false)],
+	[
+		AM_CONDITIONAL(BUILD_MANPAGES, false)
+		AM_CONDITIONAL(MANPAGES, false)
+	],
 	[
 		dnl check if whether docbook is available
 		AC_MSG_CHECKING([for applicable docbook2man])
@@ -1581,10 +1585,11 @@ AS_IF(	[test "x${ENABLE_BUILD_MANPAGES}" = "xno"],
 		AC_MSG_RESULT($ac_cv_path_docbook2man_prog)
 		AS_IF(	[test "x${ENABLE_BUILD_MANPAGES}" = "xyes" -a "x$ac_cv_path_docbook2man_prog" = "xnone"],
 			[
-				AC_MSG_ERROR([Want manpages being build but have no docbook2man])
+				AC_MSG_ERROR([Want manpages to be built but have no docbook2man])
 			],
 			[test "x$ac_cv_path_docbook2man_prog" != "xnone"],
 			[
+				AM_CONDITIONAL(BUILD_MANPAGES, true)
 				AM_CONDITIONAL(MANPAGES, true)
 				DOCBOOK2MAN="$ac_cv_path_docbook2man_prog"
 				AC_SUBST(DOCBOOK2MAN)

--- a/docs/libstatgrab/Makefile.am
+++ b/docs/libstatgrab/Makefile.am
@@ -80,7 +80,9 @@ sg_seterr_MANS=	sg_set_error.3 sg_set_error_with_errno.3 sg_clear_error.3 \
 sg_tools_MANS =	sg_update_string.3
 
 EXTRA_DIST = $(man_MANS)
+endif
 
+if BUILD_MANPAGES
 MAINTAINERCLEANFILES= $(man_MANS)
 
 .NOTPARALLEL :

--- a/docs/saidar/Makefile.am
+++ b/docs/saidar/Makefile.am
@@ -7,7 +7,9 @@ man_MANS = saidar.1
 endif
 
 EXTRA_DIST = $(man_MANS)
+endif
 
+if BUILD_MANPAGES
 MAINTAINERCLEANFILES= $(man_MANS)
 
 .xml.1:

--- a/docs/statgrab/Makefile.am
+++ b/docs/statgrab/Makefile.am
@@ -8,7 +8,9 @@ man_MANS = statgrab.1 statgrab-make-mrtg-config.1 \
 endif
 
 EXTRA_DIST = $(man_MANS)
+endif
 
+if BUILD_MANPAGES
 MAINTAINERCLEANFILES= $(man_MANS)
 
 .xml.1:


### PR DESCRIPTION
This defaults to attempting to install manpages, unless `--disable-man` is given to stop it. It defaults to not building the manpages, unless it finds docbook2man to build them with.

So for users of the release tarball this will install the manual pages from the tarball, unless requested not to.

For users of the git repository it will error if they don't have docbook2man, unless they choose to disable manual pages. I think this is reasonable because docbook2man is a required tool for build from source.