### PR TITLE
Catch processes with an unknown state

### DIFF
--- a/src/libstatgrab/process_stats.c
+++ b/src/libstatgrab/process_stats.c
@@ -552,6 +552,8 @@ sg_get_process_stats_int(sg_vector **proc_stats_vector_ptr) {
 		case 'D':
 			proc_stats_ptr[proc_items].state = SG_PROCESS_STATE_STOPPED;
 			break;
+		default:
+			proc_stats_ptr[proc_items].state = SG_PROCESS_STATE_UNKNOWN;
 		}
 
 		/* pa_name[0] should = '(' */


### PR DESCRIPTION
Catch processes with a state other than those we expect. Without this change the state is undefined, but most likely `0` which is` SG_PROCESS_STATE_RUNNING`.

A fuller fix would be to add `SG_PROCESS_STATE_IDLE` throughout the code.

Fixes #122.