### PR TITLE
configure.ac: please 'struct vmmeter'

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -1160,7 +1160,7 @@ AC_INCLUDES_DEFAULT
 			])
 		])
 
-		AC_CHECK_TYPES([struct vmtotal, struct vmmeter], , , [AC_LANG_SOURCE([
+	    AC_CHECK_TYPES([struct vmtotal, struct vmmeter], , , [AC_LANG_SOURCE([
 AC_INCLUDES_DEFAULT
 #ifdef HAVE_SYS_PARAM_H
 #include <sys/param.h>
@@ -1173,10 +1173,31 @@ AC_INCLUDES_DEFAULT
 #endif
 		])])
 
-			AC_CHECK_MEMBER(struct vmmeter.v_cache_count,
-					[AC_DEFINE(HAVE_VMMETER_V_CACHE_COUNT, 1, [v_cache_count member of struct vmmeter available])], ,
-					[AC_LANG_SOURCE([
+		# when <sys/vmmeter.h> is available but struct vmmeter not found, ask kindly for access via _WANT_VMMETER
+	    AS_IF(	[test "x$ac_cv_header_sys_vmmeter_h" = "xyes" -a "x$ac_cv_type_struct_vmmeter" != "xyes"], [
+		unset ac_cv_type_struct_vmmeter
+		AC_CHECK_TYPES([struct vmmeter], , , [AC_LANG_SOURCE([
 AC_INCLUDES_DEFAULT
+#define _WANT_VMMETER
+#ifdef HAVE_SYS_PARAM_H
+#include <sys/param.h>
+#endif
+#ifdef HAVE_SYS_SYSCTL_H
+#include <sys/sysctl.h>
+#endif
+#ifdef HAVE_SYS_VMMETER_H
+#include <sys/vmmeter.h>
+#endif
+		    ])])
+
+		AS_IF(	[test "x$ac_cv_type_struct_vmmeter" = "xyes"], [AC_DEFINE([_WANT_VMMETER], 1, [struct vmmeter needs to be pleased])], [])
+	    ])
+
+		AC_CHECK_MEMBER(struct vmmeter.v_cache_count,
+				[AC_DEFINE(HAVE_VMMETER_V_CACHE_COUNT, 1, [v_cache_count member of struct vmmeter available])], ,
+				[AC_LANG_SOURCE([
+AC_INCLUDES_DEFAULT
+#define _WANT_VMMETER
 #ifdef HAVE_SYS_PARAM_H
 # include <sys/param.h>
 #endif
@@ -1186,8 +1207,8 @@ AC_INCLUDES_DEFAULT
 #ifdef HAVE_SYS_VMMETER_H
 # include <sys/vmmeter.h>
 #endif
-					]
-			)])
+				]
+		)])
 
 		AC_CHECK_TYPES([struct xswdev, struct xsw_usage], , , [AC_LANG_SOURCE([
 AC_INCLUDES_DEFAULT

--- a/src/libstatgrab/cpu_stats.c
+++ b/src/libstatgrab/cpu_stats.c
@@ -344,12 +344,12 @@ sg_get_cpu_stats_int(sg_cpu_stats *cpu_stats_buf) {
 	size = sizeof(vmmeter);
 	memset(&vmmeter, 0, sizeof(vmmeter));
 	if( (sysctl( mib, 2, &vmmeter, &size, NULL, 0 ) == 0) && (size == sizeof(vmmeter)) ) {
-		cpu_stats_buf->context_switches = vmmeter.v_swtch;
-		cpu_stats_buf->syscalls = vmmeter.v_syscall;
-		cpu_stats_buf->syscalls += vmmeter.v_trap;
+		cpu_stats_buf->context_switches = (unsigned long long)vmmeter.v_swtch;
+		cpu_stats_buf->syscalls = (unsigned long long)vmmeter.v_syscall;
+		cpu_stats_buf->syscalls += (unsigned long long)vmmeter.v_trap;
 		cpu_stats_buf->voluntary_context_switches = cpu_stats_buf->involuntary_context_switches = 0;
-		cpu_stats_buf->interrupts = vmmeter.v_intr;
-		cpu_stats_buf->soft_interrupts = vmmeter.v_soft;
+		cpu_stats_buf->interrupts = (unsigned long long)vmmeter.v_intr;
+		cpu_stats_buf->soft_interrupts = (unsigned long long)vmmeter.v_soft;
 	}
 	else {
 		cpu_stats_buf->context_switches = 0;


### PR DESCRIPTION
According to https://github.com/libstatgrab/libstatgrab/issues/105,
FreeBSD 12+ needs a small extra please to provide struct vmmeter access.

Give it a try by adding _WANT_VMMETER define in configure stage and in case
of successful probing in such case - in config.h (which is very likely
included before sys/vmmeter.h)

Signed-off-by: Jens Rehsack <sno@netbsd.org>