### PR TITLE
configure.ac: Do not use single line comment

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -100,7 +100,8 @@ AC_TYPE_UNSIGNED_LONG_LONG_INT
 
 dnl Check for extra flags to enable some kind of behavior
 AC_CHECK_DECL([_AIX],[ac_cv_need_minus_d_linux_source_compat="yes"; ac_cv_need_minus_d_all_source="yes"])
-AC_CHECK_DECL([__linux],[ac_cv_need_minus_d_gnu_source="yes"]) dnl probably required by kfreebsd, too?
+dnl probably required by kfreebsd, too?
+AC_CHECK_DECL([__linux],[ac_cv_need_minus_d_gnu_source="yes"])
 AC_CHECK_DECL([__sun],[ac_cv_need_minus_d_extensions="yes"; ac_cv_need_minus_d_posix_pthread_semantics="yes"])
 AC_CHECK_DECL([__hpux],[ac_cv_need_minus_d_hpux_source="yes"])
 


### PR DESCRIPTION
autoconf 2.70+ does not like it and regenerating configure script fails

| ../libstatgrab-0.92/configure: line 7818: syntax error near unexpected token `ac_fn_check_decl'
| ../libstatgrab-0.92/configure: line 7818: `fi ac_fn_check_decl "$LINENO" "__sun" "ac_cv_have_decl___sun" "$ac_includes_default" "$ac_c_undeclared_builtin_options" "CFLAGS"'

Signed-off-by: Khem Raj <raj.khem@gmail.com>