### PR TITLE
{configure.ac,m4/ax_pthread.m4}: revert evaluating target

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -18,14 +18,17 @@ AC_CONFIG_SRCDIR([src/libstatgrab/cpu_stats.c])
 AC_CONFIG_MACRO_DIR([m4])
 AC_CONFIG_HEADERS([config.h])
 
+dnl Get cannonical host - the only one of build/host/target we care about
+dnl build is where we build, host the the machine we build for
+dnl
+dnl The 'build' machine		is the machine on which the software is built.
+dnl The 'host' machine		is the machine on which the software will run.
+dnl The 'target' machine	is the machine that the software is being
+dnl				configured to operate on, such as a
+dnl				cross-compiler or cross-linker.
 AC_CANONICAL_HOST
-dnl
-dnl Get cannonical target - the only one of build/host/target we care about
-dnl build is where we build, target the the machine we build for
-dnl
-AC_CANONICAL_TARGET
 dnl and store it for generic error message instead of lots of ifdef's
-AC_DEFINE_UNQUOTED([OS_TYPE], "$target_os",
+AC_DEFINE_UNQUOTED([OS_TYPE], "$host_os",
                    [Define to be the name of the operating system.])
 
 AM_INIT_AUTOMAKE([foreign -Wall -Werror])
@@ -194,7 +197,7 @@ AC_INCLUDES_DEFAULT
 	]
 )
 
-AS_CASE([$target_os],
+AS_CASE([$host_os],
  	[solaris2.[[7-9]]*], [ENABLE_DIRECT_TYPE_FMT_SEARCH_DEFAULT="size_t ssize_t"],
  	[hpux11.11], [ENABLE_DIRECT_TYPE_FMT_SEARCH_DEFAULT="size_t ssize_t"],
  	[ENABLE_DIRECT_TYPE_FMT_SEARCH_DEFAULT=])
@@ -519,7 +522,7 @@ ENABLE_THREADS_DEFAULT="check"
 # Set things up for different OS's
 # We define the name of the OS so the code can act accordingly
 # We also need to add the right LDFLAGS
-AS_CASE([$target_os],
+AS_CASE([$host_os],
 	[solaris*], [
 		AC_CHECK_HEADERS([kstat.h libdevinfo.h procfs.h sys/sockio.h])
 		AC_DEFINE(SOLARIS, 1, [Building on Solaris])
@@ -666,12 +669,12 @@ AC_INCLUDES_DEFAULT
 		LINKFLAGS="-lpdh -liphlpapi -lpsapi -lnetapi32"
 	],
 	[
-		AC_MSG_WARN([Build on unknown OS: $target_os - many functions might be not functional])
+		AC_MSG_WARN([Build on unknown OS: $host_os - many functions might be not functional])
 	]
 )
 
 dnl check Mach OS's
-AS_CASE([$target_os],
+AS_CASE([$host_os],
 	dnl Darwin, probably OSF/1, Plan9?, ...
 	[darwin*], [
 		AC_CHECK_HEADERS([mach/mach.h])
@@ -684,7 +687,7 @@ AS_CASE([$target_os],
 )
 
 dnl check BSD* OS's
-AS_CASE([$target_os],
+AS_CASE([$host_os],
 	[*bsd*|darwin*|dragonfly*], [
 		AC_DEFINE(ALLBSD, , [Building on some kind of BSD])
 		AC_MSG_CHECKING([for BSD specific features])

--- a/m4/ax_pthread.m4
+++ b/m4/ax_pthread.m4
@@ -87,11 +87,11 @@
 #   modified version of the Autoconf Macro, you may extend this special
 #   exception to the GPL to apply to your modified version as well.
 
-#serial 27
+#serial 31
 
 AU_ALIAS([ACX_PTHREAD], [AX_PTHREAD])
 AC_DEFUN([AX_PTHREAD], [
-AC_REQUIRE([AC_CANONICAL_TARGET])
+AC_REQUIRE([AC_CANONICAL_HOST])
 AC_REQUIRE([AC_PROG_CC])
 AC_REQUIRE([AC_PROG_SED])
 AC_LANG_PUSH([C])
@@ -158,7 +158,7 @@ ax_pthread_flags="pthreads none -Kthread -pthread -pthreads -mthreads pthread --
 # --thread-safe: KAI C++
 # pthread-config: use pthread-config program (for GNU Pth library)
 
-case $target_os in
+case $host_os in
 
         freebsd*)
 
@@ -248,7 +248,7 @@ AS_IF([test "x$ax_pthread_clang" = "xyes"],
 # definitions is, on some systems, a strong hint that pthreads support is
 # correctly enabled
 
-case $target_os in
+case $host_os in
         darwin* | hpux* | linux* | osf* | solaris*)
         ax_pthread_check_macro="_REENTRANT"
         ;;
@@ -391,7 +391,7 @@ if test "x$ax_pthread_clang" = "xyes"; then
              # step
              ax_pthread_save_ac_link="$ac_link"
              ax_pthread_sed='s/conftest\.\$ac_ext/conftest.$ac_objext/g'
-             ax_pthread_link_step=`$as_echo "$ac_link" | sed "$ax_pthread_sed"`
+             ax_pthread_link_step=`AS_ECHO(["$ac_link"]) | sed "$ax_pthread_sed"`
              ax_pthread_2step_ac_link="($ac_compile) && (echo ==== >&5) && ($ax_pthread_link_step)"
              ax_pthread_save_CFLAGS="$CFLAGS"
              for ax_pthread_try in '' -Qunused-arguments -Wno-unused-command-line-argument unknown; do
@@ -450,7 +450,7 @@ if test "x$ax_pthread_ok" = "xyes"; then
         AC_CACHE_CHECK([whether more special flags are required for pthreads],
             [ax_cv_PTHREAD_SPECIAL_FLAGS],
             [ax_cv_PTHREAD_SPECIAL_FLAGS=no
-             case $target_os in
+             case $host_os in
              solaris*)
              ax_cv_PTHREAD_SPECIAL_FLAGS="-D_POSIX_PTHREAD_SEMANTICS"
              ;;
@@ -480,7 +480,7 @@ if test "x$ax_pthread_ok" = "xyes"; then
 
         # More AIX lossage: compile with *_r variant
         if test "x$GCC" != "xyes"; then
-            case $target_os in
+            case $host_os in
                 aix*)
                 AS_CASE(["x/$CC"],
                     [x*/c89|x*/c89_128|x*/c99|x*/c99_128|x*/cc|x*/cc128|x*/xlc|x*/xlc_v6|x*/xlc128|x*/xlc128_v6],


### PR DESCRIPTION
According longer discussion in https://github.com/autoconf-archive/autoconf-archive/commit/2567e0ce0f3a11b535c6b527386197fb49ff172b#r52080885
relying on `$target_os` wasn't that smart as intend.

Revert:
    7ab89ec m4/ax_pthread.m4: target > host
    cd479ea configure.ac: target > host

Signed-off-by: Jens Rehsack <sno@netbsd.org>