### PR TITLE
globals.c: fix off-by-one in sg_destroy_globals component-cleanup loop

### DIFF
--- a/src/libstatgrab/globals.c
+++ b/src/libstatgrab/globals.c
@@ -475,9 +475,13 @@ sg_destroy_globals(void *glob_buf){
 # if defined(HAVE_PTHREAD)
 		int rc;
 # endif
-		size_t i = lengthof(comp_info) - 1;
-		size_t zero_size = comp_info[i].glob_ofs + comp_info[i].init_comp->static_buf_size;
+		size_t i = lengthof(comp_info);
+		size_t last_idx = lengthof(comp_info) - 1;
+		size_t zero_size = comp_info[last_idx].glob_ofs + comp_info[last_idx].init_comp->static_buf_size;
 
+		/* Walk indexes [N-1 .. 0]. The previous form started i at N-1 and
+		 * used post-decrement-in-test, which dropped the last component
+		 * (its cleanup_fn never ran -- sg_user_init's vector leaked). */
 		while(i--) {
 			if(comp_info[i].init_comp->cleanup_fn)
 				comp_info[i].init_comp->cleanup_fn(((char *)glob_buf) + comp_info[i].glob_ofs);


### PR DESCRIPTION
`sg_destroy_globals()` walks the component table to invoke each
component's `cleanup_fn`, but the loop has an off-by-one that skips
the last component:

```c
size_t i = lengthof(comp_info) - 1;
size_t zero_size = comp_info[i].glob_ofs + comp_info[i].init_comp->static_buf_size;

while (i--) {
    if (comp_info[i].init_comp->cleanup_fn)
        comp_info[i].init_comp->cleanup_fn(((char *)glob_buf) + comp_info[i].glob_ofs);
}
```

`while (i--)` evaluates `i`, then post-decrements before running the
body. So with `i = N-1` going in, the body iterations run with
`i = N-2 .. 0`. Index `N-1`, currently `sg_user_init`, never has its
`cleanup_fn` called. The `user_stats` vector and every heap-allocated
string it owns (`login_name`, `device`, `hostname`, `record_id`) leak
at every process exit.

### Reproducer

```c
#include <statgrab.h>
int main(void) {
    sg_init(1);
    size_t n;
    sg_get_user_stats(&n);
    sg_shutdown();
    return 0;
}
```

Compile against 0.92.1 with ASan, run:

```
==1248911==ERROR: LeakSanitizer: detected memory leaks

Direct leak of 1112 byte(s) in 1 object(s) allocated from:
    #0 ... __interceptor_realloc
    #1 ... sg_realloc tools.c:629
    #2 ... sg_vector_create_int vector.c:104
    #3 ... sg_vector_create vector.c:133
    #4 ... sg_get_user_stats user_stats.c:365
    #5 ... main repro.c:7
```

Plus four indirect leaks for the per-user strings.

### Fix

Start `i` at `lengthof(comp_info)` so the body runs for indexes
`N-1 .. 0` inclusive. Compute `zero_size` from a separate `last_idx`,
since `i` no longer holds a valid index outside the loop.

After the patch, the same reproducer reports zero leaks.

### Why fix the loop, not the table order

The current bug only loses `sg_user_init` because it sits at the end
of `comp_info[]`. Any future component added there would silently leak
the same way. Fixing the loop bound covers the present leak and the
regression risk in one change.